### PR TITLE
🎨 chore: remove unused deps and update postcss, version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mau-app",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mau-app",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"dependencies": {
 				"@unpic/placeholder": "^0.1.2",
 				"@unpic/svelte": "^0.0.53",
@@ -38,12 +38,12 @@
 				"prettier": "^3.1.1",
 				"prettier-plugin-svelte": "^3.1.2",
 				"svelte": "^4.2.19",
-				"svelte-check": "^3.8.6",
+				"svelte-check": "^4.0.0",
 				"svelte-turnstile": "^0.8.0",
 				"tslib": "^2.4.1",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.4.0",
-				"vite": "^5.4.2",
+				"vite": "^5.4.3",
 				"vitest": "^2.0.5"
 			}
 		},
@@ -1744,13 +1744,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/pug": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
-			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/resolve": {
 			"version": "1.20.2",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2407,16 +2400,6 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"node_modules/buffer-crc32": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2765,16 +2748,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/detect-indent": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/detect-libc": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2809,13 +2782,6 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/es6-promise": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3320,13 +3286,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3459,13 +3418,6 @@
 			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"license": "MIT"
 		},
-		"node_modules/graceful-fs": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3582,25 +3534,6 @@
 			"engines": {
 				"node": ">=0.8.19"
 			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/is-arrayish": {
 			"version": "0.3.2",
@@ -4008,16 +3941,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4031,16 +3954,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4049,19 +3962,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/mri": {
@@ -4174,16 +4074,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/onetime": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -4278,16 +4168,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -4466,9 +4346,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.4.41",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-			"integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+			"version": "8.4.44",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.44.tgz",
+			"integrity": "sha512-Aweb9unOEpQ3ezu4Q00DPvvM2ZTUitJdNKeP/+uQgr1IBIqu574IaZoURId7BKtWMREwzKa9OgzPzezWGPWFQw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4777,42 +4657,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/rollup": {
 			"version": "4.21.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.21.2.tgz",
@@ -4911,19 +4755,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/sander": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-			"integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"es6-promise": "^3.1.2",
-				"graceful-fs": "^4.1.3",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.2"
 			}
 		},
 		"node_modules/semver": {
@@ -5059,22 +4890,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
-			}
-		},
-		"node_modules/sorcery": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.1.tgz",
-			"integrity": "sha512-o7npfeJE6wi6J9l0/5LKshFzZ2rMatRiCDwYeDQaOzqdzRJwALhX7mk/A/ecg6wjMu7wdZbmXfD2S/vpOg0bdQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.14",
-				"buffer-crc32": "^1.0.0",
-				"minimist": "^1.2.0",
-				"sander": "^0.5.0"
-			},
-			"bin": {
-				"sorcery": "bin/sorcery"
 			}
 		},
 		"node_modules/source-map": {
@@ -5249,19 +5064,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strip-indent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"min-indent": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5343,24 +5145,57 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.8.6",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.8.6.tgz",
-			"integrity": "sha512-ij0u4Lw/sOTREP13BdWZjiXD/BlHE6/e2e34XzmVmsp5IN4kVa3PWP65NM32JAgwjZlwBg/+JtiNV1MM8khu0Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.0.tgz",
+			"integrity": "sha512-QgKO6OQbee9B2dyWZgrGruS3WHKrUZ718Ug53nK45vamsx93Al3on6tOrxyCMVX+OMOLLlrenn7b2VAomePwxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.17",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"chokidar": "^3.4.1",
+				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
-				"sade": "^1.7.4",
-				"svelte-preprocess": "^5.1.3",
-				"typescript": "^5.0.3"
+				"sade": "^1.7.4"
 			},
 			"bin": {
 				"svelte-check": "bin/svelte-check"
 			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
 			"peerDependencies": {
-				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
+				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-check/node_modules/fdir": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
+			"integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/svelte-check/node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
@@ -5471,69 +5306,6 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.1"
-			}
-		},
-		"node_modules/svelte-preprocess": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.1.4.tgz",
-			"integrity": "sha512-IvnbQ6D6Ao3Gg6ftiM5tdbR6aAETwjhHV+UKGf5bHGYR69RQvF1ho0JKPcbUON4vy4R7zom13jPjgdOWCQ5hDA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/pug": "^2.0.6",
-				"detect-indent": "^6.1.0",
-				"magic-string": "^0.30.5",
-				"sorcery": "^0.11.0",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 16.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.10.2",
-				"coffeescript": "^2.5.1",
-				"less": "^3.11.3 || ^4.0.0",
-				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-				"pug": "^3.0.0",
-				"sass": "^1.26.8",
-				"stylus": "^0.55.0",
-				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-				"svelte": "^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0",
-				"typescript": ">=3.9.5 || ^4.0.0 || ^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"coffeescript": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"postcss-load-config": {
-					"optional": true
-				},
-				"pug": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/svelte-turnstile": {
@@ -5946,13 +5718,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.2.tgz",
-			"integrity": "sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.4.3.tgz",
+			"integrity": "sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==",
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.21.3",
-				"postcss": "^8.4.41",
+				"postcss": "^8.4.43",
 				"rollup": "^4.20.0"
 			},
 			"bin": {
@@ -6684,13 +6456,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/yaml": {
 			"version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mau-app",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"private": true,
 	"scripts": {
 		"dev": "op run --env-file=\"./.env\" -- vite dev",
@@ -37,12 +37,12 @@
 		"prettier": "^3.1.1",
 		"prettier-plugin-svelte": "^3.1.2",
 		"svelte": "^4.2.19",
-		"svelte-check": "^3.8.6",
+		"svelte-check": "^4.0.0",
 		"svelte-turnstile": "^0.8.0",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.4.0",
-		"vite": "^5.4.2",
+		"vite": "^5.4.3",
 		"vitest": "^2.0.5"
 	},
 	"type": "module",

--- a/src/lib/services/pb.ts
+++ b/src/lib/services/pb.ts
@@ -41,8 +41,14 @@ export const sendMessage = async (name: string, email: string, message: string, 
 	}
 };
 
-export const getAllPosts = (): Promise<ListResult<Post>> => {
-	return pb.collection('posts').getList(1, 50, { sort: '-created', filter: 'publish=true' });
+export const getAllPosts = (log?: Logger): Promise<ListResult<Post>> => {
+	log?.info({ log }, 'Fetching all posts');
+	try {
+		return pb.collection('posts').getList(1, 50, { sort: '-created', filter: 'publish=true' });
+	} catch (error) {
+		log?.error({ error }, 'Error fetching all posts');
+		throw error;
+	}
 };
 
 export const getPostBySlug = async (slug: string, log?: Logger) => {

--- a/src/routes/about-me/[slug]/+page.svelte
+++ b/src/routes/about-me/[slug]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { ChevronBack, ChevronForward } from 'svelte-ionicons';
+	import type { ComponentType, SvelteComponent } from 'svelte';
 	import type { Experience } from '$lib/types';
 	import { goto } from '$app/navigation';
 
-	export let data: Object & { meta: Experience; content: string };
+	export let data: { meta: Experience; content: ComponentType<SvelteComponent> };
 
-	$: ({ content = '', meta } = data);
+	$: ({ content, meta } = data);
 
 	const LINK_PREFIX = '/about-me/';
 

--- a/src/routes/contact/+page.server.ts
+++ b/src/routes/contact/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async () => {
 };
 
 export const actions: Actions = {
-	email: async ({ request }: RequestEvent) => {
+	email: async ({ request, locals }: RequestEvent) => {
 		const form = await superValidate(request, zod(ContactSchema));
 
 		if (!form.valid) {
@@ -29,7 +29,7 @@ export const actions: Actions = {
 
 		try {
 			const { name, email, content } = form.data;
-			await sendMessage(name, email, content);
+			await sendMessage(name, email, content, locals.logger);
 			return message(form, 'Message sent successfully');
 		} catch (e) {
 			let message: string = '';

--- a/src/routes/journal/+page.server.ts
+++ b/src/routes/journal/+page.server.ts
@@ -3,13 +3,15 @@ import { getAllPosts } from '$lib/services/pb';
 import { ClientResponseError } from 'pocketbase';
 import { blurhashToCssGradientString } from '@unpic/placeholder';
 
-export async function load({ setHeaders }) {
+export async function load({ setHeaders, locals }) {
+	const log = locals.logger;
+
 	setHeaders({
 		'Cache-Control': 'max-age=3600, s-max-age=1'
 	});
 
 	try {
-		const results = await getAllPosts();
+		const results = await getAllPosts(log.child({ module: 'getAllPosts' }));
 		results.items.map((post) => {
 			post.photo_metadata.blur_hash_style = `background-image: ${blurhashToCssGradientString(post.photo_metadata.blur_hash)}`;
 		});


### PR DESCRIPTION
Remove unused dependencies to clean up the project and reduce 
potential vulnerabilities. Update PostCSS from 8.4.41 to 8.4.44 
for security fixes and improvements. Version bump from 1.0.3 
to 1.0.4. Update type for 'data' in +page.svelte.