### PR TITLE
🎨 Refactor date handling and logging improvements

### DIFF
--- a/src/lib/services/pb.ts
+++ b/src/lib/services/pb.ts
@@ -42,8 +42,8 @@ export const sendMessage = async (name: string, email: string, message: string, 
 };
 
 export const getAllPosts = (log?: Logger): Promise<ListResult<Post>> => {
-	log?.info({ log }, 'Fetching all posts');
 	try {
+		log?.info('Fetching all posts');
 		return pb.collection('posts').getList(1, 50, { sort: '-created', filter: 'publish=true' });
 	} catch (error) {
 		log?.error({ error }, 'Error fetching all posts');

--- a/src/routes/journal/+page.server.ts
+++ b/src/routes/journal/+page.server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import { getAllPosts } from '$lib/services/pb';
 import { ClientResponseError } from 'pocketbase';
 import { blurhashToCssGradientString } from '@unpic/placeholder';
+import { formatDate } from '$lib/utils';
 
 export async function load({ setHeaders, locals }) {
 	const log = locals.logger;
@@ -12,8 +13,10 @@ export async function load({ setHeaders, locals }) {
 
 	try {
 		const results = await getAllPosts(log.child({ module: 'getAllPosts' }));
+		log.info({ results: results.items.length }, 'Posts fetched successfully');
 		results.items.map((post) => {
 			post.photo_metadata.blur_hash_style = `background-image: ${blurhashToCssGradientString(post.photo_metadata.blur_hash)}`;
+			post.created = formatDate(post.created);
 		});
 		return results;
 	} catch (e) {

--- a/src/routes/journal/Posts.svelte
+++ b/src/routes/journal/Posts.svelte
@@ -3,7 +3,6 @@
 	import { Image } from '@unpic/svelte';
 	import { goto } from '$app/navigation';
 	import type { Post } from '$lib/types';
-	import { formatDate } from '$lib/utils';
 	export let posts: Post[];
 
 	interface CustomEvent extends Event {
@@ -53,7 +52,7 @@
 						<h3>{title}</h3>
 						<p>{summary}</p>
 						<p class="post-date">
-							{formatDate(created)}
+							{created}
 						</p>
 					</button>
 				</article>

--- a/src/routes/journal/[slug]/+page.server.ts
+++ b/src/routes/journal/[slug]/+page.server.ts
@@ -4,7 +4,6 @@ import { ClientResponseError } from 'pocketbase';
 
 export async function load({ params, setHeaders, locals }) {
 	const log = locals.logger;
-
 	log.info({ slug: params.slug }, 'Fetching post');
 
 	setHeaders({


### PR DESCRIPTION
- Remove unused import `formatDate` in Posts.svelte for cleanup.
- Add `formatDate` import in +page.server.ts for date formatting.
- Update `log.info` in +page.server.ts to log fetched posts count.
- Apply `formatDate` to post creation date in +page.server.ts output.
- Simplify logging message in `getAllPosts` service function for clarity.