### PR TITLE
chore: update dependencies in package-lock.json

### DIFF
--- a/.github/workflows/test-containerize-deploy.yml
+++ b/.github/workflows/test-containerize-deploy.yml
@@ -64,6 +64,23 @@ jobs:
             SECRET_CF_TURNSTILE_SECRET=${{ secrets.SECRET_CF_TURNSTILE_SECRET }}
             PUBLIC_POCKETBASE_URL=${{ secrets.PUBLIC_POCKETBASE_URL }}
 
+  semantic-release:
+    name: 'Semantic Release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 24.1.2
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+
+
   trigger-deployment:
     name: 'Trigger Deployment Workflow'
     needs: build

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,28 +22,28 @@
 				"@fastify/pre-commit": "^2.1.0",
 				"@playwright/test": "^1.47.2",
 				"@sveltejs/adapter-auto": "^3.2.5",
-				"@sveltejs/adapter-node": "^5.2.4",
+				"@sveltejs/adapter-node": "^5.2.5",
 				"@sveltejs/enhanced-img": "^0.3.8",
-				"@sveltejs/kit": "^2.5.28",
+				"@sveltejs/kit": "^2.6.1",
 				"@sveltejs/vite-plugin-svelte": "^3.1.2",
 				"@types/eslint": "^9.6.0",
-				"@types/node": "^22.6.1",
+				"@types/node": "^22.7.4",
 				"@types/prismjs": "^1.26.4",
 				"@types/uuid": "^10.0.0",
 				"eslint": "^9.11.1",
 				"eslint-config-prettier": "^9.1.0",
-				"eslint-plugin-svelte": "^2.44.0",
+				"eslint-plugin-svelte": "^2.44.1",
 				"globals": "^15.0.0",
 				"mdsvex": "0.12.3",
 				"prettier": "^3.1.1",
-				"prettier-plugin-svelte": "^3.1.2",
+				"prettier-plugin-svelte": "^3.2.7",
 				"svelte": "^4.2.19",
-				"svelte-check": "^4.0.2",
+				"svelte-check": "^4.0.4",
 				"svelte-turnstile": "^0.8.0",
 				"tslib": "^2.4.1",
 				"typescript": "^5.6.2",
 				"typescript-eslint": "^8.7.0",
-				"vite": "^5.4.7",
+				"vite": "^5.4.8",
 				"vitest": "^2.1.1"
 			}
 		},
@@ -77,9 +77,9 @@
 			"optional": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.25.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
-			"integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -90,9 +90,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.2.0.tgz",
-			"integrity": "sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.0.tgz",
+			"integrity": "sha512-XMBySMuNZs3DM96xcJmLW4EfGnf+uGmFNjzpehMjuX5PLB5j87ar2Zc4e3PVeZ3I5g3tYtAqskB28manlF69Zw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -586,9 +586,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.11.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
-			"integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
+			"integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -678,6 +678,30 @@
 				"@hapi/hoek": "^9.0.0"
 			}
 		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
+			"integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.5",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
+			"integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.0",
+				"@humanwhocodes/retry": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -693,9 +717,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/retry": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-			"integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1173,13 +1197,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.47.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
-			"integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
+			"integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.47.2"
+				"playwright": "1.48.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -1327,9 +1351,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.5.tgz",
-			"integrity": "sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+			"integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
 			"cpu": [
 				"arm"
 			],
@@ -1340,9 +1364,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.5.tgz",
-			"integrity": "sha512-S4pit5BP6E5R5C8S6tgU/drvgjtYW76FBuG6+ibG3tMvlD1h9LHVF9KmlmaUBQ8Obou7hEyS+0w+IR/VtxwNMQ==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+			"integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1353,9 +1377,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.5.tgz",
-			"integrity": "sha512-250ZGg4ipTL0TGvLlfACkIxS9+KLtIbn7BCZjsZj88zSg2Lvu3Xdw6dhAhfe/FjjXPVNCtcSp+WZjVsD3a/Zlw==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+			"integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1366,9 +1390,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.5.tgz",
-			"integrity": "sha512-D8brJEFg5D+QxFcW6jYANu+Rr9SlKtTenmsX5hOSzNYVrK5oLAEMTUgKWYJP+wdKyCdeSwnapLsn+OVRFycuQg==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+			"integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1379,9 +1403,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.5.tgz",
-			"integrity": "sha512-PNqXYmdNFyWNg0ma5LdY8wP+eQfdvyaBAojAXgO7/gs0Q/6TQJVXAXe8gwW9URjbS0YAammur0fynYGiWsKlXw==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+			"integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
 			"cpu": [
 				"arm"
 			],
@@ -1392,9 +1416,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.5.tgz",
-			"integrity": "sha512-kSSCZOKz3HqlrEuwKd9TYv7vxPYD77vHSUvM2y0YaTGnFc8AdI5TTQRrM1yIp3tXCKrSL9A7JLoILjtad5t8pQ==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+			"integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
 			"cpu": [
 				"arm"
 			],
@@ -1405,9 +1429,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.5.tgz",
-			"integrity": "sha512-oTXQeJHRbOnwRnRffb6bmqmUugz0glXaPyspp4gbQOPVApdpRrY/j7KP3lr7M8kTfQTyrBUzFjj5EuHAhqH4/w==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+			"integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1418,9 +1442,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.5.tgz",
-			"integrity": "sha512-qnOTIIs6tIGFKCHdhYitgC2XQ2X25InIbZFor5wh+mALH84qnFHvc+vmWUpyX97B0hNvwNUL4B+MB8vJvH65Fw==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+			"integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1431,9 +1455,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.5.tgz",
-			"integrity": "sha512-TMYu+DUdNlgBXING13rHSfUc3Ky5nLPbWs4bFnT+R6Vu3OvXkTkixvvBKk8uO4MT5Ab6lC3U7x8S8El2q5o56w==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+			"integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1444,9 +1468,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.5.tgz",
-			"integrity": "sha512-PTQq1Kz22ZRvuhr3uURH+U/Q/a0pbxJoICGSprNLAoBEkyD3Sh9qP5I0Asn0y0wejXQBbsVMRZRxlbGFD9OK4A==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+			"integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1457,9 +1481,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.5.tgz",
-			"integrity": "sha512-bR5nCojtpuMss6TDEmf/jnBnzlo+6n1UhgwqUvRoe4VIotC7FG1IKkyJbwsT7JDsF2jxR+NTnuOwiGv0hLyDoQ==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+			"integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
 			"cpu": [
 				"s390x"
 			],
@@ -1470,9 +1494,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.5.tgz",
-			"integrity": "sha512-N0jPPhHjGShcB9/XXZQWuWBKZQnC1F36Ce3sDqWpujsGjDz/CQtOL9LgTrJ+rJC8MJeesMWrMWVLKKNR/tMOCA==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+			"integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
 			"cpu": [
 				"x64"
 			],
@@ -1483,9 +1507,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.5.tgz",
-			"integrity": "sha512-uBa2e28ohzNNwjr6Uxm4XyaA1M/8aTgfF2T7UIlElLaeXkgpmIJ2EitVNQxjO9xLLLy60YqAgKn/AqSpCUkE9g==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+			"integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1496,9 +1520,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.5.tgz",
-			"integrity": "sha512-RXT8S1HP8AFN/Kr3tg4fuYrNxZ/pZf1HemC5Tsddc6HzgGnJm0+Lh5rAHJkDuW3StI0ynNXukidROMXYl6ew8w==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+			"integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1509,9 +1533,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.5.tgz",
-			"integrity": "sha512-ElTYOh50InL8kzyUD6XsnPit7jYCKrphmddKAe1/Ytt74apOxDq5YEcbsiKs0fR3vff3jEneMM+3I7jbqaMyBg==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+			"integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1522,9 +1546,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.5.tgz",
-			"integrity": "sha512-+lvL/4mQxSV8MukpkKyyvfwhH266COcWlXE/1qxwN08ajovta3459zrjLghYMgDerlzNwLAcFpvU+WWE5y6nAQ==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+			"integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
 			"cpu": [
 				"x64"
 			],
@@ -1565,13 +1589,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/@sodaru/yup-to-json-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@sodaru/yup-to-json-schema/-/yup-to-json-schema-2.0.1.tgz",
-			"integrity": "sha512-lWb0Wiz8KZ9ip/dY1eUqt7fhTPmL24p6Hmv5Fd9pzlzAdw/YNcWZr+tiCT4oZ4Zyxzi9+1X4zv82o7jYvcFxYA==",
-			"license": "MIT License",
-			"optional": true
-		},
 		"node_modules/@sveltejs/adapter-auto": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.2.5.tgz",
@@ -1586,9 +1603,9 @@
 			}
 		},
 		"node_modules/@sveltejs/adapter-node": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.2.5.tgz",
-			"integrity": "sha512-FVeysFqeIlKFpDF1Oj38gby34f6uA9FuXnV330Z0RHmSyOR9JzJs70/nFKy1Ue3fWtf7S0RemOrP66Vr9Jcmew==",
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.2.6.tgz",
+			"integrity": "sha512-FT9MDduZT2srUz/gDFFhQ3U2Mp9reZ3xJdJBEhr/lk+dkieSSpdgIDNNbMkm84hTaXXiC7f4cPNk8fB5nT3N2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1602,14 +1619,14 @@
 			}
 		},
 		"node_modules/@sveltejs/enhanced-img": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@sveltejs/enhanced-img/-/enhanced-img-0.3.8.tgz",
-			"integrity": "sha512-n66u46ZeqHltiTm0BEjWptYmCrCY0EltEEvakmC7d5o5ZejDbOvOWm914mebbRKaP2Bezv65TNCod/wqvw/0KA==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@sveltejs/enhanced-img/-/enhanced-img-0.3.9.tgz",
+			"integrity": "sha512-hDhoIbkDAY08II/1DWeY2lGMY9nhETC96B2HTbxoI6EDqxLErBDKqnRN3QQRuMJATxPGVNhCKUkuARi4TCLtpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"magic-string": "^0.30.5",
-				"svelte-parse-markup": "^0.1.2",
+				"svelte-parse-markup": "^0.1.5",
 				"vite-imagetools": "^7.0.1"
 			},
 			"peerDependencies": {
@@ -1618,9 +1635,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.6.1.tgz",
-			"integrity": "sha512-QFlch3GPGZYidYhdRAub0fONw8UTguPICFHUSPxNkA/jdlU1p6C6yqq19J1QWdxIHS2El/ycDCGrHb3EAiMNqg==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.7.0.tgz",
+			"integrity": "sha512-4XyY1SCB/Eyz8E9G7SEBKViysYwVtDftuA7kyQ5bmuFNPWC1KZC4988rMvaJxhH2BbCTsbLPjNOZwiEGXt8/2g==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1719,9 +1736,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-			"integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+			"version": "22.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1797,17 +1814,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
-			"integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.1.tgz",
+			"integrity": "sha512-xfvdgA8AP/vxHgtgU310+WBnLB4uJQ9XdyP17RebG26rLtDrQJV3ZYrcopX91GrHmMoH8bdSwMRh2a//TiJ1jQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.7.0",
-				"@typescript-eslint/type-utils": "8.7.0",
-				"@typescript-eslint/utils": "8.7.0",
-				"@typescript-eslint/visitor-keys": "8.7.0",
+				"@typescript-eslint/scope-manager": "8.8.1",
+				"@typescript-eslint/type-utils": "8.8.1",
+				"@typescript-eslint/utils": "8.8.1",
+				"@typescript-eslint/visitor-keys": "8.8.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1831,16 +1848,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
-			"integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.1.tgz",
+			"integrity": "sha512-hQUVn2Lij2NAxVFEdvIGxT9gP1tq2yM83m+by3whWFsWC+1y8pxxxHUFE1UqDu2VsGi2i6RLcv4QvouM84U+ow==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.7.0",
-				"@typescript-eslint/types": "8.7.0",
-				"@typescript-eslint/typescript-estree": "8.7.0",
-				"@typescript-eslint/visitor-keys": "8.7.0",
+				"@typescript-eslint/scope-manager": "8.8.1",
+				"@typescript-eslint/types": "8.8.1",
+				"@typescript-eslint/typescript-estree": "8.8.1",
+				"@typescript-eslint/visitor-keys": "8.8.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1860,14 +1877,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
-			"integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.1.tgz",
+			"integrity": "sha512-X4JdU+66Mazev/J0gfXlcC/dV6JI37h+93W9BRYXrSn0hrE64IoWgVkO9MSJgEzoWkxONgaQpICWg8vAN74wlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.7.0",
-				"@typescript-eslint/visitor-keys": "8.7.0"
+				"@typescript-eslint/types": "8.8.1",
+				"@typescript-eslint/visitor-keys": "8.8.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1878,14 +1895,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
-			"integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.1.tgz",
+			"integrity": "sha512-qSVnpcbLP8CALORf0za+vjLYj1Wp8HSoiI8zYU5tHxRVj30702Z1Yw4cLwfNKhTPWp5+P+k1pjmD5Zd1nhxiZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.7.0",
-				"@typescript-eslint/utils": "8.7.0",
+				"@typescript-eslint/typescript-estree": "8.8.1",
+				"@typescript-eslint/utils": "8.8.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -1903,9 +1920,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
-			"integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.1.tgz",
+			"integrity": "sha512-WCcTP4SDXzMd23N27u66zTKMuEevH4uzU8C9jf0RO4E04yVHgQgW+r+TeVTNnO1KIfrL8ebgVVYYMMO3+jC55Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1917,14 +1934,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
-			"integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.1.tgz",
+			"integrity": "sha512-A5d1R9p+X+1js4JogdNilDuuq+EHZdsH9MjTVxXOdVFfTJXunKJR/v+fNNyO4TnoOn5HqobzfRlc70NC6HTcdg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "8.7.0",
-				"@typescript-eslint/visitor-keys": "8.7.0",
+				"@typescript-eslint/types": "8.8.1",
+				"@typescript-eslint/visitor-keys": "8.8.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1972,16 +1989,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
-			"integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.1.tgz",
+			"integrity": "sha512-/QkNJDbV0bdL7H7d0/y0qBbV2HTtf0TIyjSDTvvmQEzeVx8jEImEbLuOA4EsvE8gIgqMitns0ifb5uQhMj8d9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.7.0",
-				"@typescript-eslint/types": "8.7.0",
-				"@typescript-eslint/typescript-estree": "8.7.0"
+				"@typescript-eslint/scope-manager": "8.8.1",
+				"@typescript-eslint/types": "8.8.1",
+				"@typescript-eslint/typescript-estree": "8.8.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1995,13 +2012,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
-			"integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.1.tgz",
+			"integrity": "sha512-0/TdC3aeRAsW7MDvYRwEc1Uwm0TIBfzjPFgg60UU2Haj5qsCs9cc3zNgY71edqE3LbWfF/WoZQd3lJoDXFQpag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.7.0",
+				"@typescript-eslint/types": "8.8.1",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
@@ -2088,14 +2105,14 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.1.tgz",
-			"integrity": "sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.2.tgz",
+			"integrity": "sha512-FEgtlN8mIUSEAAnlvn7mP8vzaWhEaAEvhSXCqrsijM7K6QqjB11qoRZYEd4AKSCDz8p0/+yH5LzhZ47qt+EyPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.1",
-				"@vitest/utils": "2.1.1",
+				"@vitest/spy": "2.1.2",
+				"@vitest/utils": "2.1.2",
 				"chai": "^5.1.1",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -2104,9 +2121,9 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.1.tgz",
-			"integrity": "sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.2.tgz",
+			"integrity": "sha512-ExElkCGMS13JAJy+812fw1aCv2QO/LBK6CyO4WOPAzLTmve50gydOlWhgdBJPx2ztbADUq3JVI0C5U+bShaeEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2118,7 +2135,7 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/spy": "2.1.1",
+				"@vitest/spy": "2.1.2",
 				"msw": "^2.3.5",
 				"vite": "^5.0.0"
 			},
@@ -2142,9 +2159,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.1.tgz",
-			"integrity": "sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.2.tgz",
+			"integrity": "sha512-FIoglbHrSUlOJPDGIrh2bjX1sNars5HbxlcsFKCtKzu4+5lpsRhOCVcuzp0fEhAGHkPZRIXVNzPcpSlkoZ3LuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2155,13 +2172,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.1.tgz",
-			"integrity": "sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.2.tgz",
+			"integrity": "sha512-UCsPtvluHO3u7jdoONGjOSil+uON5SSvU9buQh3lP7GgUXHp78guN1wRmZDX4wGK6J10f9NUtP6pO+SFquoMlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "2.1.1",
+				"@vitest/utils": "2.1.2",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -2169,13 +2186,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.1.tgz",
-			"integrity": "sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.2.tgz",
+			"integrity": "sha512-xtAeNsZ++aRIYIUsek7VHzry/9AcxeULlegBvsdLncLmNCR6tR8SRjn8BbDP4naxtccvzTqZ+L1ltZlRCfBZFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.1",
+				"@vitest/pretty-format": "2.1.2",
 				"magic-string": "^0.30.11",
 				"pathe": "^1.1.2"
 			},
@@ -2184,9 +2201,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.1.tgz",
-			"integrity": "sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.2.tgz",
+			"integrity": "sha512-GSUi5zoy+abNRJwmFhBDC0yRuVUn8WMlQscvnbbXdKLXX9dE59YbfwXxuJ/mth6eeqIzofU8BB5XDo/Ns/qK2A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2197,13 +2214,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.1.tgz",
-			"integrity": "sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.2.tgz",
+			"integrity": "sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.1",
+				"@vitest/pretty-format": "2.1.2",
 				"loupe": "^3.1.1",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -2260,16 +2277,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -2841,9 +2848,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.11.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
-			"integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.12.0.tgz",
+			"integrity": "sha512-UVIOlTEWxwIopRL1wgSQYdnVDcEvs2wyaO6DGo5mXqe3r16IoCNWkR29iHhyaP4cICWjbgbmFUGAhh0GJRuGZw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2852,11 +2859,11 @@
 				"@eslint/config-array": "^0.18.0",
 				"@eslint/core": "^0.6.0",
 				"@eslint/eslintrc": "^3.1.0",
-				"@eslint/js": "9.11.1",
+				"@eslint/js": "9.12.0",
 				"@eslint/plugin-kit": "^0.2.0",
+				"@humanfs/node": "^0.16.5",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.3.0",
-				"@nodelib/fs.walk": "^1.2.8",
+				"@humanwhocodes/retry": "^0.3.1",
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
@@ -2864,9 +2871,9 @@
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.0.2",
-				"eslint-visitor-keys": "^4.0.0",
-				"espree": "^10.1.0",
+				"eslint-scope": "^8.1.0",
+				"eslint-visitor-keys": "^4.1.0",
+				"espree": "^10.2.0",
 				"esquery": "^1.5.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -2876,13 +2883,11 @@
 				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
-				"is-path-inside": "^3.0.3",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3",
-				"strip-ansi": "^6.0.1",
 				"text-table": "^0.2.0"
 			},
 			"bin": {
@@ -3163,9 +3168,9 @@
 			}
 		},
 		"node_modules/fdir": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
-			"integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+			"integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -3265,16 +3270,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-func-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3289,9 +3284,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "15.9.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
-			"integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+			"version": "15.11.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
+			"integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3483,16 +3478,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-reference": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -3622,9 +3607,9 @@
 			}
 		},
 		"node_modules/libphonenumber-js": {
-			"version": "1.11.9",
-			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.9.tgz",
-			"integrity": "sha512-Zs5wf5HaWzW2/inlupe2tstl0I/Tbqo7lH20ZLr6Is58u7Dz2n+gRFGNlj9/gWxFvNfp9+YyDsiegjNhdixB9A==",
+			"version": "1.11.11",
+			"resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.11.tgz",
+			"integrity": "sha512-mF3KaORjJQR6JBNcOkluDcJKhtoQT4VTLRMrX1v/wlBayL4M8ybwEDeryyPcrSEJmD0rVwHUbBarpZwN5NfPFQ==",
 			"license": "MIT",
 			"optional": true
 		},
@@ -3668,19 +3653,16 @@
 			"license": "MIT"
 		},
 		"node_modules/loupe": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
-			"integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
 			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"get-func-name": "^2.0.1"
-			}
+			"license": "MIT"
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.11",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"version": "0.30.12",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+			"integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
@@ -4031,13 +4013,13 @@
 			"license": "MIT"
 		},
 		"node_modules/playwright": {
-			"version": "1.47.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
-			"integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
+			"integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.47.2"
+				"playwright-core": "1.48.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4050,9 +4032,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.47.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
-			"integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+			"version": "1.48.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
+			"integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4313,9 +4295,9 @@
 			}
 		},
 		"node_modules/readdirp": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
-			"integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+			"integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4382,9 +4364,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.22.5",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.5.tgz",
-			"integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
+			"version": "4.24.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+			"integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.6"
@@ -4397,22 +4379,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.22.5",
-				"@rollup/rollup-android-arm64": "4.22.5",
-				"@rollup/rollup-darwin-arm64": "4.22.5",
-				"@rollup/rollup-darwin-x64": "4.22.5",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.22.5",
-				"@rollup/rollup-linux-arm-musleabihf": "4.22.5",
-				"@rollup/rollup-linux-arm64-gnu": "4.22.5",
-				"@rollup/rollup-linux-arm64-musl": "4.22.5",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.22.5",
-				"@rollup/rollup-linux-riscv64-gnu": "4.22.5",
-				"@rollup/rollup-linux-s390x-gnu": "4.22.5",
-				"@rollup/rollup-linux-x64-gnu": "4.22.5",
-				"@rollup/rollup-linux-x64-musl": "4.22.5",
-				"@rollup/rollup-win32-arm64-msvc": "4.22.5",
-				"@rollup/rollup-win32-ia32-msvc": "4.22.5",
-				"@rollup/rollup-win32-x64-msvc": "4.22.5",
+				"@rollup/rollup-android-arm-eabi": "4.24.0",
+				"@rollup/rollup-android-arm64": "4.24.0",
+				"@rollup/rollup-darwin-arm64": "4.24.0",
+				"@rollup/rollup-darwin-x64": "4.24.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.24.0",
+				"@rollup/rollup-linux-arm64-musl": "4.24.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.24.0",
+				"@rollup/rollup-linux-x64-gnu": "4.24.0",
+				"@rollup/rollup-linux-x64-musl": "4.24.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.24.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.24.0",
+				"@rollup/rollup-win32-x64-msvc": "4.24.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -4665,19 +4647,6 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4759,9 +4728,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.4.tgz",
-			"integrity": "sha512-AcHWIPuZb1mh/jKoIrww0ebBPpAvwWd1bfXCnwC2dx4OkydNMaiG//+Xnry91RJMHFH7CiE+6Y2p332DRIaOXQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.0.5.tgz",
+			"integrity": "sha512-icBTBZ3ibBaywbXUat3cK6hB5Du+Kq9Z8CRuyLmm64XIe2/r+lQcbuBx/IQgsbrC+kT2jQ0weVpZSSRIPwB6jQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4924,9 +4893,9 @@
 			}
 		},
 		"node_modules/sveltekit-superforms": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/sveltekit-superforms/-/sveltekit-superforms-2.19.0.tgz",
-			"integrity": "sha512-WJmdYf8WpuDkl6zxdRP72R+wDefx1OhIQYKdsIQqNkFntNq0/BUrkMdUr1i7d/FbX0gS1A9GRflCx3WiYQlAXg==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/sveltekit-superforms/-/sveltekit-superforms-2.19.1.tgz",
+			"integrity": "sha512-P3R3S8o+0UGHtVqmisb13aFVuIyTCsFdxh/2C/fvoR9/JKeBrhzJ/chI7GdByoXE5fr2DtanocGXmP3PRTcpvw==",
 			"funding": [
 				{
 					"type": "github",
@@ -4943,7 +4912,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"devalue": "^5.0.0",
+				"devalue": "^5.1.1",
 				"just-clone": "^6.2.0",
 				"memoize-weak": "^1.0.2",
 				"ts-deepmerge": "^7.0.1"
@@ -4952,7 +4921,6 @@
 				"@exodus/schemasafe": "^1.3.0",
 				"@gcornut/valibot-json-schema": "^0.31.0",
 				"@sinclair/typebox": "^0.32.35",
-				"@sodaru/yup-to-json-schema": "^2.0.1",
 				"@typeschema/class-validator": "^0.2.0",
 				"@vinejs/vine": "^1.8.0",
 				"arktype": "2.0.0-rc.8",
@@ -5192,9 +5160,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5206,15 +5174,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
-			"integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.8.1.tgz",
+			"integrity": "sha512-R0dsXFt6t4SAFjUSKFjMh4pXDtq04SsFKCVGDP3ZOzNP7itF0jBcZYU4fMsZr4y7O7V7Nc751dDeESbe4PbQMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.7.0",
-				"@typescript-eslint/parser": "8.7.0",
-				"@typescript-eslint/utils": "8.7.0"
+				"@typescript-eslint/eslint-plugin": "8.8.1",
+				"@typescript-eslint/parser": "8.8.1",
+				"@typescript-eslint/utils": "8.8.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5393,9 +5361,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.1.tgz",
-			"integrity": "sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.2.tgz",
+			"integrity": "sha512-HPcGNN5g/7I2OtPjLqgOtCRu/qhVvBxTUD3qzitmL0SrG1cWFzxzhMDWussxSbrRYWqnKf8P2jiNhPMSN+ymsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5849,19 +5817,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.1.tgz",
-			"integrity": "sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.2.tgz",
+			"integrity": "sha512-veNjLizOMkRrJ6xxb+pvxN6/QAWg95mzcRjtmkepXdN87FNfxAss9RKe2far/G9cQpipfgP2taqg0KiWsquj8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "2.1.1",
-				"@vitest/mocker": "2.1.1",
-				"@vitest/pretty-format": "^2.1.1",
-				"@vitest/runner": "2.1.1",
-				"@vitest/snapshot": "2.1.1",
-				"@vitest/spy": "2.1.1",
-				"@vitest/utils": "2.1.1",
+				"@vitest/expect": "2.1.2",
+				"@vitest/mocker": "2.1.2",
+				"@vitest/pretty-format": "^2.1.2",
+				"@vitest/runner": "2.1.2",
+				"@vitest/snapshot": "2.1.2",
+				"@vitest/spy": "2.1.2",
+				"@vitest/utils": "2.1.2",
 				"chai": "^5.1.1",
 				"debug": "^4.3.6",
 				"magic-string": "^0.30.11",
@@ -5872,7 +5840,7 @@
 				"tinypool": "^1.0.0",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.1.1",
+				"vite-node": "2.1.2",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -5887,8 +5855,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "2.1.1",
-				"@vitest/ui": "2.1.1",
+				"@vitest/browser": "2.1.2",
+				"@vitest/ui": "2.1.2",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -1,22 +1,15 @@
 {
-	"name": "mau-app",
-	"version": "1.0.6",
-	"private": true,
-	"scripts": {
-		"dev": "op run --env-file=\"./.env\" -- vite dev",
-		"build": "vite build",
-		"preview": "vite preview",
-		"test": "npm run test:integration && npm run test:unit",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint": "prettier --check . && eslint .",
-		"format": "prettier --write .",
-		"test:integration": "playwright test",
-		"test:unit": "vitest"
+	"dependencies": {
+		"@unpic/placeholder": "^0.1.2",
+		"@unpic/svelte": "^0.0.53",
+		"pino": "^9.4.0",
+		"pocketbase": "^0.21.3",
+		"prismjs": "^1.29.0",
+		"svelte-ionicons": "^1.1.2",
+		"sveltekit-superforms": "^2.19.0",
+		"uuid": "^10.0.0",
+		"zod": "^3.23.8"
 	},
-	"pre-commit": [
-		"format"
-	],
 	"devDependencies": {
 		"@fastify/pre-commit": "^2.1.0",
 		"@playwright/test": "^1.47.2",
@@ -45,16 +38,33 @@
 		"vite": "^5.4.8",
 		"vitest": "^2.1.1"
 	},
+	"name": "mau-app",
+	"pre-commit": [
+		"format"
+	],
+	"private": true,
+	"release": {
+		"branches": [
+			"main"
+		],
+		"plugins": [
+			"@semantic-release/commit-analyzer",
+			"@semantic-release/release-notes-generator",
+			"@semantic-release/changelog"
+		]
+	},
+	"scripts": {
+		"build": "vite build",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"dev": "op run --env-file=\"./.env\" -- vite dev",
+		"format": "prettier --write .",
+		"lint": "prettier --check . && eslint .",
+		"preview": "vite preview",
+		"test": "npm run test:integration && npm run test:unit",
+		"test:integration": "playwright test",
+		"test:unit": "vitest"
+	},
 	"type": "module",
-	"dependencies": {
-		"@unpic/placeholder": "^0.1.2",
-		"@unpic/svelte": "^0.0.53",
-		"pino": "^9.4.0",
-		"pocketbase": "^0.21.3",
-		"prismjs": "^1.29.0",
-		"svelte-ionicons": "^1.1.2",
-		"sveltekit-superforms": "^2.19.0",
-		"uuid": "^10.0.0",
-		"zod": "^3.23.8"
-	}
+	"version": "1.0.6"
 }


### PR DESCRIPTION
Updates several dependencies to their latest versions, 
improving functionality and security. The following packages 
are updated: @rollup/rollup-android-arm-eabi (4.24.0), 
vite-node (2.1.2), playwright (1.48.0), 
@sveltejs/adapter-node (5.2.6), 
@typescript-eslint/visitor-keys (8.8.1), 
and svelte-check (4.0.5). Outdated dependency 
strip-ansi is removed.