### PR TITLE
fix(ci): update permissions for semantic release job

### DIFF
--- a/.github/workflows/test-containerize-deploy.yml
+++ b/.github/workflows/test-containerize-deploy.yml
@@ -65,6 +65,9 @@ jobs:
             PUBLIC_POCKETBASE_URL=${{ secrets.PUBLIC_POCKETBASE_URL }}
 
   semantic-release:
+    permissions:
+      contents: write
+      pull-requests: write
     name: 'Semantic Release'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-containerize-deploy.yml
+++ b/.github/workflows/test-containerize-deploy.yml
@@ -65,6 +65,7 @@ jobs:
             PUBLIC_POCKETBASE_URL=${{ secrets.PUBLIC_POCKETBASE_URL }}
 
   semantic-release:
+    needs: test
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -32,6 +32,7 @@ jobs:
           HOME: /root
 
   semantic-release:
+    needs: test
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -30,3 +30,23 @@ jobs:
         run: npx playwright test
         env:
           HOME: /root
+
+  semantic-release:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: 'Semantic Release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          dry_run: true
+          semantic_version: 24.1.2
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}


### PR DESCRIPTION
Add write permissions for contents and pull-requests in  
the semantic-release job to enable automated workflows  
that require these permissions for successful deployments.