### PR TITLE
chore: update semantic-release plugins configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,14 @@
 				}
 			],
 			[
-				"@semantic-release/npm",
+				"@semantic-release/git",
 				{
-					"publish": false
+					"publish": false,
+					"assets": [
+						"package.json",
+						"CHANGELOG.md"
+					],
+					"message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
 				}
 			]
 		]


### PR DESCRIPTION
Replace "@semantic-release/npm" with "@semantic-release/git" in 
the semantic release configuration. Enable asset tracking for 
"package.json" and "CHANGELOG.md" to ensure they are included 
in the release commit. Update the commit message format for 
consistency and clarity in release logs.