### PR TITLE
feat(release): configure npm publish settings in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
 				}
 			],
 			[
+				"@semantic-release/npm",
+				{
+					"publish": false
+				}
+			],
+			[
 				"@semantic-release/git",
 				{
 					"publish": false,


### PR DESCRIPTION
Add configuration for @semantic-release/npm to prevent 
publishing to the npm registry. This change ensures that 
the package only commits changes to the repository without 
publishing artifacts, aligning the release process with 
project requirements.