### PR TITLE
style: update CSS variables for consistency and clarity

### DIFF
--- a/src/routes/journal/page/[page]/Posts.svelte
+++ b/src/routes/journal/page/[page]/Posts.svelte
@@ -132,9 +132,8 @@
 		border: 1px solid var(--theme-background-secondary);
 		padding: 0 1rem;
 		border-radius: var(--theme-border-radius-default);
-		/* box-shadow: 6px 6px 8px 3px rgba(0, 0, 0, 0.3); */
+		box-shadow: 6px 6px 8px 3px rgba(0, 0, 0, 0.3);
 		font-size: 1.2rem;
-		color: var(--theme-background-secondary);
 	}
 
 	.post-date {

--- a/static/css/general.css
+++ b/static/css/general.css
@@ -239,6 +239,7 @@ a {
 	font-weight: var(--theme-font-weight-default);
 	letter-spacing: var(--theme-font-leter-spacing-default);
 	line-height: var(--theme-font-line-height-default);
+	color: var(--theme-font-default);
 }
 
 /* Pico CSS */


### PR DESCRIPTION
Set the text color in general.css to use the theme font color.   Re-enable the box-shadow for post elements in Posts.svelte to enhance   visual depth and maintain design consistency.