### PR TITLE
chore: update dependencies and enhance code quality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"eslint": "9.18.0",
 				"eslint-config-prettier": "^10.0.1",
 				"eslint-plugin-svelte": "^2.46.1",
-				"globals": "15.14.0",
+				"globals": "16.0.0",
 				"mdsvex": "0.12.3",
 				"prettier": "3.4.2",
 				"prettier-plugin-svelte": "3.3.3",
@@ -43,7 +43,7 @@
 				"tslib": "^2.8.1",
 				"typescript": "5.7.3",
 				"typescript-eslint": "8.21.0",
-				"vite": "6.0.10",
+				"vite": "6.2.0",
 				"vitest": "3.0.2"
 			}
 		},
@@ -102,9 +102,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-			"integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+			"integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -118,9 +118,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-			"integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+			"integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
 			"cpu": [
 				"arm"
 			],
@@ -134,9 +134,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-			"integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+			"integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -150,9 +150,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-			"integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+			"integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
 			"cpu": [
 				"x64"
 			],
@@ -166,9 +166,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-			"integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+			"integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
 			"cpu": [
 				"arm64"
 			],
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-			"integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+			"integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
 			"cpu": [
 				"x64"
 			],
@@ -198,9 +198,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
 			"cpu": [
 				"arm64"
 			],
@@ -214,9 +214,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-			"integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+			"integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
 			"cpu": [
 				"x64"
 			],
@@ -230,9 +230,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-			"integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+			"integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
 			"cpu": [
 				"arm"
 			],
@@ -246,9 +246,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-			"integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+			"integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
 			"cpu": [
 				"arm64"
 			],
@@ -262,9 +262,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-			"integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+			"integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
 			"cpu": [
 				"ia32"
 			],
@@ -278,9 +278,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-			"integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+			"integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
 			"cpu": [
 				"loong64"
 			],
@@ -294,9 +294,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-			"integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+			"integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -310,9 +310,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-			"integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+			"integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -326,9 +326,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-			"integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+			"integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -342,9 +342,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-			"integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+			"integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
 			"cpu": [
 				"s390x"
 			],
@@ -358,9 +358,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-			"integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+			"integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
 			"cpu": [
 				"x64"
 			],
@@ -374,9 +374,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -390,9 +390,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+			"integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
 			"cpu": [
 				"x64"
 			],
@@ -406,9 +406,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-			"integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+			"integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
 			"cpu": [
 				"arm64"
 			],
@@ -422,9 +422,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-			"integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+			"integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
 			"cpu": [
 				"x64"
 			],
@@ -438,9 +438,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-			"integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+			"integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
 			"cpu": [
 				"x64"
 			],
@@ -454,9 +454,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-			"integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+			"integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
 			"cpu": [
 				"arm64"
 			],
@@ -470,9 +470,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-			"integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+			"integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
 			"cpu": [
 				"ia32"
 			],
@@ -486,9 +486,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-			"integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+			"integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2741,9 +2741,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.24.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+			"integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -2753,31 +2753,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.24.2",
-				"@esbuild/android-arm": "0.24.2",
-				"@esbuild/android-arm64": "0.24.2",
-				"@esbuild/android-x64": "0.24.2",
-				"@esbuild/darwin-arm64": "0.24.2",
-				"@esbuild/darwin-x64": "0.24.2",
-				"@esbuild/freebsd-arm64": "0.24.2",
-				"@esbuild/freebsd-x64": "0.24.2",
-				"@esbuild/linux-arm": "0.24.2",
-				"@esbuild/linux-arm64": "0.24.2",
-				"@esbuild/linux-ia32": "0.24.2",
-				"@esbuild/linux-loong64": "0.24.2",
-				"@esbuild/linux-mips64el": "0.24.2",
-				"@esbuild/linux-ppc64": "0.24.2",
-				"@esbuild/linux-riscv64": "0.24.2",
-				"@esbuild/linux-s390x": "0.24.2",
-				"@esbuild/linux-x64": "0.24.2",
-				"@esbuild/netbsd-arm64": "0.24.2",
-				"@esbuild/netbsd-x64": "0.24.2",
-				"@esbuild/openbsd-arm64": "0.24.2",
-				"@esbuild/openbsd-x64": "0.24.2",
-				"@esbuild/sunos-x64": "0.24.2",
-				"@esbuild/win32-arm64": "0.24.2",
-				"@esbuild/win32-ia32": "0.24.2",
-				"@esbuild/win32-x64": "0.24.2"
+				"@esbuild/aix-ppc64": "0.25.0",
+				"@esbuild/android-arm": "0.25.0",
+				"@esbuild/android-arm64": "0.25.0",
+				"@esbuild/android-x64": "0.25.0",
+				"@esbuild/darwin-arm64": "0.25.0",
+				"@esbuild/darwin-x64": "0.25.0",
+				"@esbuild/freebsd-arm64": "0.25.0",
+				"@esbuild/freebsd-x64": "0.25.0",
+				"@esbuild/linux-arm": "0.25.0",
+				"@esbuild/linux-arm64": "0.25.0",
+				"@esbuild/linux-ia32": "0.25.0",
+				"@esbuild/linux-loong64": "0.25.0",
+				"@esbuild/linux-mips64el": "0.25.0",
+				"@esbuild/linux-ppc64": "0.25.0",
+				"@esbuild/linux-riscv64": "0.25.0",
+				"@esbuild/linux-s390x": "0.25.0",
+				"@esbuild/linux-x64": "0.25.0",
+				"@esbuild/netbsd-arm64": "0.25.0",
+				"@esbuild/netbsd-x64": "0.25.0",
+				"@esbuild/openbsd-arm64": "0.25.0",
+				"@esbuild/openbsd-x64": "0.25.0",
+				"@esbuild/sunos-x64": "0.25.0",
+				"@esbuild/win32-arm64": "0.25.0",
+				"@esbuild/win32-ia32": "0.25.0",
+				"@esbuild/win32-x64": "0.25.0"
 			}
 		},
 		"node_modules/esbuild-runner": {
@@ -3277,9 +3277,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "15.14.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
-			"integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+			"integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3968,9 +3968,9 @@
 			"license": "MIT"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5170,14 +5170,14 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.0.10",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.0.10.tgz",
-			"integrity": "sha512-MEszunEcMo6pFsfXN1GhCFQqnE25tWRH0MA4f0Q7uanACi4y1Us+ZGpTMnITwCTnYzB2b9cpmnelTlxgTBmaBA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.0.tgz",
+			"integrity": "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==",
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.24.2",
-				"postcss": "^8.4.49",
-				"rollup": "^4.23.0"
+				"esbuild": "^0.25.0",
+				"postcss": "^8.5.3",
+				"rollup": "^4.30.1"
 			},
 			"bin": {
 				"vite": "bin/vite.js"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"eslint": "9.18.0",
 		"eslint-config-prettier": "^10.0.1",
 		"eslint-plugin-svelte": "^2.46.1",
-		"globals": "15.14.0",
+		"globals": "16.0.0",
 		"mdsvex": "0.12.3",
 		"prettier": "3.4.2",
 		"prettier-plugin-svelte": "3.3.3",
@@ -35,7 +35,7 @@
 		"tslib": "^2.8.1",
 		"typescript": "5.7.3",
 		"typescript-eslint": "8.21.0",
-		"vite": "6.0.10",
+		"vite": "6.2.0",
 		"vitest": "3.0.2"
 	},
 	"name": "mau-app",

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Mauricio Mercado | AI & Software Engineering Consultant</title>
 
 		<!-- Preload fonts -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -39,6 +40,6 @@
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
+		<div class="sveltekit-body-wrapper">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/app.html
+++ b/src/app.html
@@ -24,6 +24,7 @@
 			crossorigin="anonymous"
 			referrerpolicy="no-referrer"
 		/>
+
 		<link
 			rel="stylesheet"
 			href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.conditional.min.css"

--- a/src/constants/techStack.ts
+++ b/src/constants/techStack.ts
@@ -43,7 +43,7 @@ import Cloudinary from '../components/icons/tech/Cloudinary.svelte';
 
 export interface TechStack {
 	category: string;
-	icon: new (options: { target: HTMLElement; props?: Record<string, any> }) => SvelteComponent;
+	icon: new (options: { target: HTMLElement; props?: Record<string, unknown> }) => SvelteComponent;
 	name: string;
 	duplicate?: boolean;
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -20,7 +20,7 @@ function logRequest(
 
 	// Filter out null or undefined fields
 	const filteredLogData = Object.fromEntries(
-		Object.entries(logData).filter(([_, value]) => value != null)
+		Object.entries(logData).filter(([, value]) => value != null)
 	);
 
 	if (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,11 +11,10 @@ export function splitArrayIntoChunks<T>(arr: T[], numChunks: number): T[][] {
 	const chunks: T[][] = [];
 	const n = arr.length;
 	const chunkSize = Math.floor(n / numChunks);
-	const remainder = n % numChunks;
 
 	for (let i = 0; i < numChunks; i++) {
-		let start = i * chunkSize;
-		let end = start + chunkSize;
+		const start = i * chunkSize;
+		const end = start + chunkSize;
 		chunks.push(arr.slice(start, end));
 	}
 

--- a/src/routes/about-me/+page.svelte
+++ b/src/routes/about-me/+page.svelte
@@ -2,7 +2,7 @@
 	import type { Experience } from '$lib/types';
 	import Timeline from './Timeline.svelte';
 
-	export let data: Object & { experiences: Experience[] };
+	export let data: object & { experiences: Experience[] };
 </script>
 
 <svelte:head>
@@ -105,9 +105,8 @@
 				Outside my work life, I firmly believe in the ethos of lifelong learning. My GitHub
 				portfolio <a href="https://github.com/maumercado">https://github.com/maumercado</a> provides
 				a glimpse of my wide-ranging skills and interests, featuring projects like a React Native
-				app with Expo, my blog
-				<a href="https://codigos.notion.site">https://codigos.notion.site</a>, and two Fastify
-				plugins, one for the Jaeger distributed tracing system​, and the second a plugin to inject
+				app with Expo, my blog <a href="https://codigo.sh">https://codigo.sh</a>, and two Fastify
+				plugins, one for the Jaeger distributed tracing system, and the second a plugin to inject
 				secrets store in hashicorp vault into the service's environment at boot.
 			</p>
 			<p>

--- a/src/routes/about-me/Timeline.svelte
+++ b/src/routes/about-me/Timeline.svelte
@@ -19,7 +19,6 @@
 		{#each experiences as entry, index}
 			<li class="timeline-entry">
 				<p class="timeline-id">{entry.timeframe}</p>
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
 				<button
 					class="timeline-content"
 					class:timeline-content--flipped={index % 2 !== 0}

--- a/src/routes/about-me/[slug]/+page.svelte
+++ b/src/routes/about-me/[slug]/+page.svelte
@@ -29,7 +29,7 @@
 	<div class="navigation-links pico">
 		<button
 			on:click={() => handleClick(meta.previous)}
-			disabled={!Boolean(meta.previous)}
+			disabled={!meta.previous}
 			class="goto outline contrast"
 			role="link"
 		>
@@ -37,7 +37,7 @@
 		</button>
 		<button
 			on:click={() => handleClick(meta.next)}
-			disabled={!Boolean(meta.next)}
+			disabled={!meta.next}
 			class="goto next outline contrast"
 			role="link"
 		>

--- a/src/routes/about-me/[slug]/+page.ts
+++ b/src/routes/about-me/[slug]/+page.ts
@@ -9,6 +9,7 @@ export async function load({ params }) {
 			meta: { ...experience.metadata, slug: params.slug }
 		};
 	} catch (e) {
+		console.error(e);
 		error(404, `Could not find ${params.slug}`);
 	}
 }

--- a/src/routes/journal/[slug]/+page.svelte
+++ b/src/routes/journal/[slug]/+page.svelte
@@ -3,6 +3,15 @@
 	import { Image } from '@unpic/svelte';
 	import { type Post } from '$lib/types';
 	import Prism from 'prismjs';
+	import 'prismjs/components/prism-python';
+	import 'prismjs/components/prism-bash';
+	import 'prismjs/components/prism-javascript';
+	import 'prismjs/components/prism-typescript';
+	import 'prismjs/components/prism-json';
+	import 'prismjs/components/prism-css';
+	import 'prismjs/components/prism-markup';
+	import 'prismjs/components/prism-markdown';
+	import 'prismjs/components/prism-yaml';
 	import { onMount } from 'svelte';
 	export let data: Post;
 
@@ -32,6 +41,7 @@
 			on:load={onLoadImage}
 		/>
 	</div>
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html content}
 </article>
 

--- a/src/routes/journal/page/[page]/+page.svelte
+++ b/src/routes/journal/page/[page]/+page.svelte
@@ -6,7 +6,7 @@
 	import Posts from './Posts.svelte';
 	import Pagination from './Pagination.svelte';
 
-	$: ({ page, perPage, items, totalItems, totalPages } = data);
+	$: ({ page, totalPages } = data);
 </script>
 
 <Posts posts={data.items} />

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module '*?enhanced' {
-	const value: any;
+	const value: unknown;
 	export = value;
 }
 

--- a/static/css/general.css
+++ b/static/css/general.css
@@ -423,3 +423,8 @@ a:active {
 	box-sizing: border-box;
 	animation: rotationBack 4s linear infinite reverse;
 }
+
+/* SvelteKit body wrapper */
+.sveltekit-body-wrapper {
+	display: contents;
+}


### PR DESCRIPTION
Upgrade Vite to version 6.2.0 and improve code maintenance by adding 
additional Prism.js components for syntax highlighting. Update 
@esbuild packages to version 0.25.0 and globals package to 16.0.0 to 
ensure compatibility and take advantage of the latest features and 
bug fixes. Add error logging in the load function and make minor 
type adjustments in the TechStack interface.