### PR TITLE
style: add default font color to heading elements

### DIFF
--- a/static/css/general.css
+++ b/static/css/general.css
@@ -205,12 +205,14 @@ h1 {
 	font-size: var(--theme-font-size-xlarge);
 	font-weight: var(--theme-font-weight-xlarge);
 	line-height: var(--theme-font-line-height-xlarge);
+	color: var(--theme-font-default);
 }
 
 h2 {
 	font-size: var(--theme-font-size-large);
 	font-weight: var(--theme-font-weight-large);
 	line-height: var(--theme-font-line-height-large);
+	color: var(--theme-font-default);
 }
 
 h3,
@@ -218,12 +220,14 @@ h3,
 	font-size: var(--theme-font-size-medium);
 	font-weight: var(--theme-font-weight-medium);
 	line-height: var(--theme-font-line-height-medium);
+	color: var(--theme-font-default);
 }
 
 h4 {
 	font-size: var(--theme-font-size-small);
 	font-weight: var(--theme-font-weight-medium);
 	line-height: var(--theme-font-line-height-medium);
+	color: var(--theme-font-default);
 }
 
 li,


### PR DESCRIPTION
### Pull Request Description

**Title:** style: add default font color to heading elements

**Description:**
This pull request introduces a default font color for heading elements (h1, h2, h3, and h4) in the `general.css` file. The primary goal of this update is to achieve consistent text coloring across all heading levels, which enhances readability and aligns the headings more closely with the overall theme of the project. 

**Changes made:**
- Defined a default font color for h1, h2, h3, and h4 in `general.css` to ensure visual coherence.

By merging this PR, we will improve the overall aesthetic and user experience of our application.